### PR TITLE
Switch to CSV stats

### DIFF
--- a/src/ScraperProxy/scraper.cpp
+++ b/src/ScraperProxy/scraper.cpp
@@ -1,5 +1,8 @@
 #include "scraper.h"
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+
 extern bool fShutdown;
 
 bool find(const std::string& s, const std::string& find);
@@ -697,14 +700,9 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
 
     _log(INFO, "ProcessProjectRacFileByCPID", "Started processing " + file.string());
 
-    stringbuilder outdata;
-    outdata.nlappend("<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>");
-    stream << outdata.value();
-
+    std::vector<std::string> vXML;
     bool bcomplete = false;
     bool bfileerror = false;
-    std::vector<std::string> vXML;
-
     while (!bcomplete && !bfileerror)
     {
         // Find users block
@@ -793,29 +791,14 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     // In reality we DO NOT need total_credit till TCD
     // In reality we DO NOT need expavg_time but this will make nn compatible
     // I've also opted to save 1 byte a line by not doing newlines since this a scraper
-
-    stringbuilder xmlout;
-
-    xmlout.nlappend("<users>");
-
+    stream << "# total_credit,expavg_time,expavgcredit,cpid" << std::endl;
     for (auto const& vv : vXML)
     {
-        std::string stotal_credit = ExtractXML(vv, "<total_credit>", "</total_credit>");
-        std::string sexpavg_time = ExtractXML(vv, "<expavg_time>", "</expavg_time>");
-        std::string sexpavg_credit = ExtractXML(vv, "<expavg_credit>", "</expavg_credit>");
-        std::string scpid = ExtractXML(vv, "<cpid>", "</cpid>");
-
-        xmlout.nlappend("<user>");
-        xmlout.xmlappend("total_credit", stotal_credit);
-        xmlout.xmlappend("expavg_time", sexpavg_time);
-        xmlout.xmlappend("expavg_credit", sexpavg_credit);
-        xmlout.xmlappend("cpid", scpid);
-        xmlout.nlappend("</user>");
+        stream << ExtractXML(vv, "<total_credit>", "</total_credit>") << ","
+               << ExtractXML(vv, "<expavg_time>", "</expavg_time>") << ","
+               << ExtractXML(vv, "<expavg_credit>", "</expavg_credit>") << ","
+               << ExtractXML(vv, "<cpid>", "</cpid>") << std::endl;
     }
-
-    xmlout.nlappend("</users>");
-
-    stream << xmlout.value();
 
     _log(INFO, "ProcessProjectRacFileByCPID", "Finished processing team rac data; stripping complete");
 
@@ -1358,94 +1341,28 @@ bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& fi
     bool bfileerror = false;
     std::vector<std::string> vXML;
 
-    while (!bcomplete && !bfileerror)
-    {
-        // Find users block
-        std::string line;
-
-        while (std::getline(in, line))
-        {
-            if (line != "<users>")
-                continue;
-
-            else
-                break;
-        }
-        // <users> block found
-        // Lets vector the  <user> blocks
-
-        while (std::getline(in, line))
-        {
-            if (bcomplete)
-                break;
-
-            if (line == "</users>")
-            {
-                bcomplete = true;
-
-                break;
-            }
-
-            if (line == "<user>")
-            {
-                stringbuilder userdata;
-
-                userdata.nlappend(line);
-
-                //_log(INFO, "\nLoadProjectFileToStatsByCPID", "Line: " + line);
-
-                while (std::getline(in, line))
-                {
-                    //_log(INFO, "LoadProjectFileToStatsByCPID", "Line: " + line);
-
-                    if (line == "</user>")
-                    {
-                        userdata.nlappend(line);
-
-                        //_log(INFO, "LoadProjectFileToStatsByCPID", "userdata: \n" + userdata.value());
-
-                        std::string sCPID = ExtractXML(userdata.value(), "<cpid>", "</cpid>");
-
-                        //_log(INFO, "LoadProjectFileToStatsByCPID", "CPID: " + sCPID);
-
-                        // This uses the passed in beacon map to refilter the statistics.
-                        if (mBeaconMap.count(sCPID) >= 1)
-                            vXML.push_back(userdata.value());
-
-                        break;
-                    }
-
-                    userdata.nlappend(line);
-                }
-            }
-        }
-
-        // If the file is complete/incomplete we will reach here. however bcomplete would be true to break this outter most loop.
-        // In case where we reach here but the bool for bcomplete is not true then the file was incomplete!
-        if (!bcomplete)
-            bfileerror = true;
-    }
-
-    ingzfile.close();
-
-    if (bfileerror)
-    {
-        _log(CRITICAL, "LoadProjectFileToStatsByCPID", "Error in data processing of " + file.string() + "; Aborted processing");
-        return false;
-    }
-
-    // Iterate through vector elements and populate map for byCPIDbyProject statistics. Compute project totals at the same time, because
-    // we will need it next to compute magnitudes.
+    // Lets vector the user blocks
+    std::string line;
     double dProjectTC = 0.0;
     double dProjectRAT = 0.0;
     double dProjectRAC = 0.0;
-    for (auto const& vv : vXML)
+    while (std::getline(in, line))
     {
+        if(line[0] == '#')
+            continue;
+
+        std::vector<std::string> fields;
+        boost::split(fields, line, boost::is_any_of(","), boost::token_compress_on);
+
+        if(fields.size() < 4)
+            continue;
+
         ScraperObjectStats statsentry = {};
 
-        std::string sTC = ExtractXML(vv, "<total_credit>", "</total_credit>");
-        std::string sRAT = ExtractXML(vv, "<expavg_time>", "</expavg_time>");
-        std::string sRAC = ExtractXML(vv, "<expavg_credit>", "</expavg_credit>");
+        const std::string& sTC = fields[0];
+        const std::string& sRAT = fields[1];
+        const std::string& sRAC = fields[2];
+        const std::string& cpid = fields[3];
 
         // Replace blank strings with zeros.
         statsentry.statsvalue.dTC = (sTC.empty()) ? 0.0 : std::stod(sTC);
@@ -1454,7 +1371,7 @@ bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& fi
         // Mag is dealt with on the second pass... so is left at 0.0 on the first pass.
 
         statsentry.statskey.objecttype = byCPIDbyProject;
-        statsentry.statskey.objectID = project + "," + ExtractXML(vv, "<cpid>", "</cpid>");
+        statsentry.statskey.objectID = project + "," + cpid;
 
         // Insert stats entry into map by the key.
         mScraperStats[statsentry.statskey] = statsentry;
@@ -1465,7 +1382,9 @@ bool LoadProjectFileToStatsByCPID(const std::string& project, const fs::path& fi
         dProjectRAC += statsentry.statsvalue.dRAC;
     }
 
-        _log(INFO, "LoadProjectFileToStatsByCPID", "There are " + std::to_string(mScraperStats.size()) + " CPID entries for " + project);
+    ingzfile.close();
+
+    _log(INFO, "LoadProjectFileToStatsByCPID", "There are " + std::to_string(mScraperStats.size()) + " CPID entries for " + project);
 
     // The mScraperStats here is scoped to only this project so we do not need project filtering here.
     ScraperStats::iterator entry;


### PR DESCRIPTION
This PR changes the output from compressed XML to compressed CSV for ~15% size reduction. It also tightens the code which does the XML->CSV conversion so we don't have to copy the stream, and it minimizes the amount of data needed to be stored in memory.

TODO:
- Handle output stream errors
- Test performance vs current implementation

```
marco@dev:~/.GridcoinResearch/testnet/Scraper$ zcat yoyo@home-543d95-57c99fd582d8c-ByCPID.gz 
# total_credit,expavg_time,expavgcredit,cpid
6324095.7995661544136603.5136750.387719af73cd19f79a0ade8e6ef695faa2c776
18818918.6409621544375687.872448306216.97590517029c4576fc8e66b21dfec118099199
1693220.6648951544342507.0414771866.22739659900fe7ef44fe33aa2afdf98301ec1c
....
```