### PR TITLE
Fix link errors

### DIFF
--- a/src/neuralnet/neuralnet.cpp
+++ b/src/neuralnet/neuralnet.cpp
@@ -1,7 +1,6 @@
 #include "neuralnet.h"
 #include "neuralnet_native.h"
 #include "neuralnet_stub.h"
-#include "util.h"
 
 
 
@@ -12,6 +11,19 @@
 extern bool GetBoolArg(const std::string& strArg, bool fDefault);
 
 using namespace NN;
+
+namespace
+{
+    INeuralNetPtr instance;
+}
+
+INeuralNetPtr NN::CreateNeuralNet()
+{
+#if defined(QT_GUI) && defined(WIN32)
+    return std::make_shared<NeuralNetWin32>();
+#else
+    return std::make_shared<NeuralNetStub>();
+#endif
 
 namespace
 {
@@ -31,11 +43,11 @@ INeuralNetPtr NN::CreateNeuralNet()
 }
 
 void NN::SetInstance(const INeuralNetPtr &obj)
-{
+    {
     instance = obj;
-}
+    }
 
 INeuralNetPtr NN::GetInstance()
-{
+    {
     return instance;
 }

--- a/src/neuralnet/neuralnet.h
+++ b/src/neuralnet/neuralnet.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <memory>
+#include <functional>
 
 namespace NN
 {
@@ -13,7 +14,7 @@ namespace NN
         //!
         //! \brief Destructor.
         //!
-        virtual ~INeuralNet() = default;
+        virtual ~INeuralNet() {}
 
         //!
         //! \brief Check is current system supports neural net operations.
@@ -87,10 +88,30 @@ namespace NN
     typedef std::shared_ptr<INeuralNet> INeuralNetPtr;
 
     //!
+    //! \brief Factory function.
+    //!
+    typedef std::function<INeuralNetPtr()> Factory;
+
+    //!
+    //! \brief Register factory function.
+    //!
+    //! Registers a factory function which will be called by
+    //! \p CreateNeuralNet.
+    //!
+    //! \param factory
+    //!
+    void RegisterFactory(const Factory& factory);
+
+    //!
     //! \brief Neuralnet factory.
     //!
     //! Evaluates host platform and configuration flags to instantiate an
     //! appropriate neuralnet object.
+    //!
+    //! This creates an object using the following criterias and order:
+    //!  1) New neuralnet if enabled
+    //!  2) Old neuralnet if factory has been registered, see RegisterFactory().
+    //!  3) A neural net stub.
     //!
     //! \return A new INeuralNet instance.
     //!

--- a/src/neuralnet/neuralnet_win.cpp
+++ b/src/neuralnet/neuralnet_win.cpp
@@ -14,8 +14,6 @@
 #include <cstdio>
 #include <string>
 
-using namespace NN;
-
 // Old VB based NeuralNet.
 extern std::string qtGetNeuralHash(std::string data);
 extern std::string qtGetNeuralContract(std::string data);
@@ -23,6 +21,19 @@ extern double qtExecuteGenericFunction(std::string function,std::string data);
 extern std::string qtExecuteDotNetStringFunction(std::string function,std::string data);
 extern void qtSyncWithDPORNodes(std::string data);
 int64_t IsNeural();
+
+using namespace NN;
+
+namespace
+{
+    // Static factory registration.
+    bool registered = []()
+    {
+        NN::Factory factory([]() { return std::make_shared<NeuralNetWin32>(); });
+        NN::RegisterFactory(factory);
+        return true;
+    };
+}
 
 // While transitioning to dotnet the NeuralNet implementation has been split
 // into 3 implementations; Win32 with Qt, Win32 without Qt and the rest.

--- a/src/neuralnet/neuralnet_win.cpp
+++ b/src/neuralnet/neuralnet_win.cpp
@@ -14,6 +14,8 @@
 #include <cstdio>
 #include <string>
 
+using namespace NN;
+
 // Old VB based NeuralNet.
 extern std::string qtGetNeuralHash(std::string data);
 extern std::string qtGetNeuralContract(std::string data);
@@ -21,8 +23,6 @@ extern double qtExecuteGenericFunction(std::string function,std::string data);
 extern std::string qtExecuteDotNetStringFunction(std::string function,std::string data);
 extern void qtSyncWithDPORNodes(std::string data);
 int64_t IsNeural();
-
-using namespace NN;
 
 // While transitioning to dotnet the NeuralNet implementation has been split
 // into 3 implementations; Win32 with Qt, Win32 without Qt and the rest.
@@ -65,4 +65,3 @@ int64_t NeuralNetWin32::IsNeuralNet()
 {
     return IsNeural();
 }
-


### PR DESCRIPTION
Fix link errors in the Win32 NN. The solution is a bit over the top but we can remove all of the factory registration shenanigans when we remove the old NN.