### PR TITLE
Provide for keying std::unordered_map with NN::QuorumHash objects

### DIFF
--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -744,6 +744,18 @@ bool QuorumHash::Valid() const
     return Which() != Kind::INVALID;
 }
 
+const unsigned char* QuorumHash::Raw() const
+{
+    switch (Which()) {
+        case Kind::INVALID:
+            return nullptr;
+        case Kind::SHA256:
+            return boost::get<uint256>(m_hash).begin();
+        case Kind::MD5:
+            return boost::get<Md5Sum>(m_hash).data();
+    }
+}
+
 std::string QuorumHash::ToString() const
 {
     return boost::apply_visitor(QuorumHashToStringVisitor(), m_hash);

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -1470,4 +1470,32 @@ BOOST_AUTO_TEST_CASE(it_represents_itself_as_a_string)
     BOOST_CHECK(hash.ToString() == "00000000000000000000000000000000");
 }
 
+BOOST_AUTO_TEST_CASE(it_is_hashable_to_key_a_lookup_map)
+{
+    std::hash<NN::QuorumHash> hasher;
+
+    NN::QuorumHash hash_invalid;
+
+    BOOST_CHECK(hasher(hash_invalid) == 0);
+
+    NN::QuorumHash hash_sha256(uint256(std::vector<unsigned char> {
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    }));
+
+
+    // 0x01 + 0x02 + 0x03 + 0x04 (SHA256 quarters, big endian)
+    BOOST_CHECK(hasher(hash_sha256) == 10);
+
+    NN::QuorumHash hash_md5(std::array<unsigned char, 16> {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+    });
+
+    // 0x0706050403020100 + 0x1514131211100908 (MD5 halves, little endian)
+    BOOST_CHECK(hasher(hash_md5) == 2024957465561532936);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -342,9 +342,19 @@ public:
         return (unsigned char*)&pn[0];
     }
 
+    const unsigned char* begin() const
+    {
+        return (const unsigned char*)&pn[0];
+    }
+
     unsigned char* end()
     {
         return (unsigned char*)&pn[WIDTH];
+    }
+
+    const unsigned char* end() const
+    {
+        return (const unsigned char*)&pn[WIDTH];
     }
 
     unsigned int size()


### PR DESCRIPTION
This allows us to create unordered maps from the quorum hash objects instead of converting to a string each time.