### PR TITLE
Add superblock WellFormed() and GetHash() methods

### DIFF
--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -445,6 +445,13 @@ std::string Superblock::PackLegacy() const
     return out.str();
 }
 
+bool Superblock::WellFormed() const
+{
+    return m_version > 0 && m_version <= Superblock::CURRENT_VERSION
+        && !m_cpids.empty()
+        && !m_projects.empty();
+}
+
 bool Superblock::ConvergedByProject() const
 {
     return m_projects.m_converged_by_project;

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -406,6 +406,10 @@ Superblock Superblock::FromStats(const ScraperStats& stats)
 
 Superblock Superblock::UnpackLegacy(const std::string& packed)
 {
+    if (packed.empty()) {
+        return Superblock(1);
+    }
+
     // Legacy-packed superblocks always initialize to version 1:
     Superblock superblock(1);
     LegacySuperblockParser legacy(packed);

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -466,9 +466,13 @@ int64_t Superblock::Age() const
     return GetAdjustedTime() - m_timestamp;
 }
 
-QuorumHash Superblock::GetHash() const
+QuorumHash Superblock::GetHash(const bool regenerate) const
 {
-    return QuorumHash::Hash(*this);
+    if (!m_hash_cache.Valid() || regenerate) {
+        m_hash_cache = QuorumHash::Hash(*this);
+    }
+
+    return m_hash_cache;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -840,3 +840,15 @@ std::string QuorumHash::ToString() const
 {
     return boost::apply_visitor(QuorumHashToStringVisitor(), m_hash);
 }
+
+unsigned int QuorumHash::GetSerializeSize(int nType, int nVersion) const
+{
+    switch (Which()) {
+        case Kind::SHA256: return 1 + sizeof(uint256);
+        case Kind::MD5:    return 1 + sizeof(Md5Sum);
+
+        // For variants without any associated data, we serialize the variant
+        // tag only as a single byte:
+        default:           return 1;
+    }
+}

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -466,6 +466,11 @@ int64_t Superblock::Age() const
     return GetAdjustedTime() - m_timestamp;
 }
 
+QuorumHash Superblock::GetHash() const
+{
+    return QuorumHash::Hash(*this);
+}
+
 // -----------------------------------------------------------------------------
 // Class: Superblock::CpidIndex
 // -----------------------------------------------------------------------------

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -599,6 +599,13 @@ public:
     std::string PackLegacy() const;
 
     //!
+    //! \brief Determine whether the instance represents a complete superblock.
+    //!
+    //! \return \c true if the superblock contains all of the required elements.
+    //!
+    bool WellFormed() const;
+
+    //!
     //! \brief Determine whether the superblock was generated from a fallback-
     //! to-project-level scraper convergence.
     //!

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -619,6 +619,14 @@ public:
     //! \return Superblock age in seconds.
     //!
     int64_t Age() const;
+
+    //!
+    //! \brief Get a hash of the significant data in the superblock.
+    //!
+    //! \return A quorum hash object that contiains a SHA256 hash for version
+    //! 2+ superblocks or an MD5 hash for legacy version 1 superblocks.
+    //!
+    QuorumHash GetHash() const;
 }; // Superblock
 
 //!

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -4932,7 +4932,7 @@ bool ScraperSynchronizeDPOR()
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache)
 {
     // Calculate the hash of the superblock to validate.
-    NN::QuorumHash nNewFormatSuperblockHash = SerializeHash(NewFormatSuperblock);
+    NN::QuorumHash nNewFormatSuperblockHash = NewFormatSuperblock.GetHash();
 
     // manifest hash hint (reduced hash) from superblock...
     uint32_t nReducedSBContentHash = NewFormatSuperblock.m_convergence_hint;
@@ -4946,7 +4946,7 @@ scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperb
 
         // If there is no superblock returned, the node is either out of sync, or has not
         // received enough manifests and parts to calculate a convergence. Return unknown.
-        if (!CurrentNodeSuperblock.GetSerializeSize(SER_NETWORK, 1)) return scraperSBvalidationtype::Unknown;
+        if (!CurrentNodeSuperblock.WellFormed()) return scraperSBvalidationtype::Unknown;
 
         LOCK(cs_ConvergedScraperStatsCache);
 

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -773,6 +773,34 @@ BOOST_AUTO_TEST_CASE(it_generates_its_quorum_hash)
     BOOST_CHECK(superblock.GetHash() == NN::QuorumHash::Hash(superblock));
 }
 
+BOOST_AUTO_TEST_CASE(it_caches_its_quorum_hash)
+{
+    NN::Superblock superblock;
+
+    // Cache the hash:
+    NN::QuorumHash original_hash = superblock.GetHash();
+
+    // Change the resulting hash:
+    superblock.m_cpids.Add(NN::Cpid(), 123);
+
+    // The cached hash should not change:
+    BOOST_CHECK(superblock.GetHash() == original_hash);
+}
+
+BOOST_AUTO_TEST_CASE(it_regenerates_its_cached_quorum_hash)
+{
+    NN::Superblock superblock;
+
+    // Cache the hash:
+    superblock.GetHash();
+
+    // Change the resulting hash:
+    superblock.m_cpids.Add(NN::Cpid(), 123);
+
+    // Regenrate the hash:
+    BOOST_CHECK(superblock.GetHash(true) == NN::QuorumHash::Hash(superblock));
+}
+
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
 {
     std::vector<unsigned char> expected {

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -766,6 +766,13 @@ BOOST_AUTO_TEST_CASE(it_calculates_its_age)
     BOOST_CHECK(superblock.Age() < GetAdjustedTime());
 }
 
+BOOST_AUTO_TEST_CASE(it_generates_its_quorum_hash)
+{
+    NN::Superblock superblock;
+
+    BOOST_CHECK(superblock.GetHash() == NN::QuorumHash::Hash(superblock));
+}
+
 BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
 {
     std::vector<unsigned char> expected {

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -707,6 +707,34 @@ BOOST_AUTO_TEST_CASE(it_provides_backward_compatibility_for_legacy_contracts)
     BOOST_CHECK(Legacy::GetQuorumHash(unpacked) == expected_hash);
 }
 
+BOOST_AUTO_TEST_CASE(it_determines_whether_it_represents_a_complete_superblock)
+{
+    NN::Superblock valid;
+
+    valid.m_cpids.Add(NN::Cpid(), 123);
+    valid.m_projects.Add("name", NN::Superblock::ProjectStats());
+
+    BOOST_CHECK(valid.WellFormed() == true);
+
+    NN::Superblock invalid = valid;
+
+    invalid.m_version = 0;
+    BOOST_CHECK(invalid.WellFormed() == false);
+
+    invalid.m_version = std::numeric_limits<decltype(invalid.m_version)>::max();
+    BOOST_CHECK(invalid.WellFormed() == false);
+
+    invalid = valid;
+
+    invalid.m_cpids = NN::Superblock::CpidIndex();
+    BOOST_CHECK(invalid.WellFormed() == false);
+
+    invalid = valid;
+
+    invalid.m_projects = NN::Superblock::ProjectIndex();
+    BOOST_CHECK(invalid.WellFormed() == false);
+}
+
 BOOST_AUTO_TEST_CASE(it_checks_whether_it_was_created_from_fallback_convergence)
 {
     NN::Superblock superblock;

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -668,6 +668,15 @@ BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_text_contract)
     }
 }
 
+BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_superblock_for_empty_strings)
+{
+    NN::Superblock superblock = NN::Superblock::UnpackLegacy("");
+
+    BOOST_CHECK(superblock.m_version == 1);
+    BOOST_CHECK(superblock.m_cpids.empty());
+    BOOST_CHECK(superblock.m_projects.empty());
+}
+
 BOOST_AUTO_TEST_CASE(it_provides_backward_compatibility_for_legacy_contracts)
 {
     const std::string legacy_contract(


### PR DESCRIPTION
Cherry-picking superblock improvements that support `ValidateSuperblock()` and some other minor superblock enhancements.

Note: I reordered `NN::QuorumHash` before `NN::Superblock` in superblock.h because the superblock class needs the definition to allow for the hash caching. 