### PR TITLE
Create SuperblockValidator class

### DIFF
--- a/src/neuralnet/neuralnet_native.cpp
+++ b/src/neuralnet/neuralnet_native.cpp
@@ -13,7 +13,6 @@ extern std::string ExplainMagnitude(std::string sCPID);
 using namespace NN;
 
 extern Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
-extern QuorumHash ScraperGetSuperblockHash();
 
 bool NeuralNetNative::IsEnabled()
 {
@@ -34,7 +33,7 @@ std::string NeuralNetNative::GetNeuralHash()
 
 QuorumHash NeuralNetNative::GetSuperblockHash()
 {
-    return ScraperGetSuperblockHash();
+    return GetSuperblockContract().GetHash();
 }
 
 std::string NeuralNetNative::GetNeuralContract()

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1,5 +1,9 @@
+#include "net.h" // TODO: needed for scraper_net.h
+#include <univalue.h> // TODO: needed for scraper_net.h
+
 #include "compat/endian.h"
 #include "neuralnet/superblock.h"
+#include "scraper_net.h"
 #include "util.h"
 
 #include <boost/variant/apply_visitor.hpp>
@@ -10,7 +14,675 @@ using namespace NN;
 std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 std::string ExtractValue(std::string data, std::string delimiter, int pos);
 
+// TODO: use a header
+ScraperStats GetScraperStatsByConvergedManifest(ConvergedManifest& StructConvergedManifest);
+ScraperStats GetScraperStatsFromSingleManifest(CScraperManifest &manifest);
+unsigned int NumScrapersForSupermajority(unsigned int nScraperCount);
+mmCSManifestsBinnedByScraper ScraperDeleteCScraperManifests();
+Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
+
+extern CCriticalSection cs_ConvergedScraperStatsCache;
+extern ConvergedScraperStats ConvergedScraperStatsCache;
+
 namespace {
+//!
+//! \brief Validates received superblocks against the local scraper manifest
+//! data to prevent superblock statistics spoofing attacks.
+//!
+//! When a node publishes a superblock in a generated block, every node in the
+//! network validates the superblock by comparing it to manifest data received
+//! from the scrapers. For validation to pass, a node must generate a matching
+//! superblock from the local manifest data.
+//!
+class SuperblockValidator
+{
+public:
+    //!
+    //! \brief Describes a superblock validation outcome.
+    //!
+    enum class Result
+    {
+        UNKNOWN,           //!< Not enough manifest data to try validation.
+        INVALID,           //!< It does not match a valid set of manifest data.
+        VALID_CURRENT,     //!< It matches the current cached convergence.
+        VALID_PAST,        //!< It matches a cached past convergence.
+        VALID_BY_MANIFEST, //!< It matches a single manifest supermajority.
+        VALID_BY_PROJECT,  //!< It matches by-project fallback supermajority.
+    };
+
+    //!
+    //! \brief Create a new validator for the provided superblock.
+    //!
+    //! \param superblock The superblock data to validate.
+    //!
+    SuperblockValidator(const Superblock& superblock)
+        : m_superblock(superblock)
+        , m_quorum_hash(superblock.GetHash())
+    {
+    }
+
+    //!
+    //! \brief Perform the validation of the superblock.
+    //!
+    //! \param use_cache If \c false, skip attempts to validate the superblock
+    //! using the cached scraper convergences.
+    //!
+    //! \return A value that describes the outcome of the validation.
+    //!
+    Result Validate(const bool use_cache = true) const
+    {
+        const Superblock local_contract = ScraperGetSuperblockContract(true);
+
+        // If we cannot produce a superblock for comparison from the local set
+        // of manifest data, we don't have enough context to try to validate a
+        // superblock. Skip the validation and rely on peers to validate it.
+        //
+        if (!local_contract.WellFormed()) {
+            return Result::UNKNOWN;
+        }
+
+        if (use_cache) {
+            if (m_quorum_hash == local_contract.GetHash()) {
+                return Result::VALID_CURRENT;
+            }
+
+            LogPrintf("ValidateSuperblock(): No match to current convergence.");
+
+            if (TryRecentPastConvergence()) {
+                return Result::VALID_PAST;
+            }
+        }
+
+        LogPrintf("ValidateSuperblock(): No match using cached convergence.");
+
+        if (!m_superblock.ConvergedByProject() && TryByManifest()) {
+            return Result::VALID_BY_MANIFEST;
+        }
+
+        LogPrintf("ValidateSuperblock(): No match by manifest.");
+
+        if (m_superblock.ConvergedByProject() && TryProjectFallback()) {
+            return Result::VALID_BY_PROJECT;
+        }
+
+        LogPrintf("ValidateSuperblock(): No match by project.");
+
+        return Result::INVALID;
+    }
+
+private: // SuperblockValidator classes
+
+    //!
+    //! \brief Maintains the context of a whitelisted project for validating
+    //! fallback-to-project convergence scenarios.
+    //!
+    struct ResolvedProject
+    {
+        //!
+        //! \brief The manifest part hashes procured from the convergence hints
+        //! in the superblock that may correspond to the parts of this project.
+        //!
+        //! The \c ProjectResolver will attempt to match these hashes to a part
+        //! contained in a manifest for each scraper to find a supermajority.
+        //!
+        std::set<uint256> m_candidate_hashes;
+
+        //!
+        //! \brief The set of scrapers that produced the matching manifest part
+        //! for the project.
+        //!
+        //! This set must hold at least the mininum number of scraper IDs for a
+        //! supermajority for each project or the superblock validation fails.
+        //!
+        std::set<ScraperID> m_scrapers;
+
+        //!
+        //! \brief The manifest part hashes found in a manifest published by a
+        //! scraper used to retrieve the part for the project to construct the
+        //! convergence for comparison to the superblock.
+        //!
+        //! Keyed by timestamp.
+        //!
+        //! After successfully matching each of the convergence hints in the
+        //! superblock to a manifest project, the \c ProjectResolver selects
+        //! the most recent part of each \c ResolvedProject to construct the
+        //! final convergence.
+        //!
+        std::map<int64_t, uint256> m_resolved_parts;
+
+        //!
+        //! \brief Initialize a new project context object.
+        //!
+        ResolvedProject()
+        {
+        }
+
+        //!
+        //! \brief Initialize a new project context object.
+        //!
+        //! \param candidate hashes The manifest part hashes procured from the
+        //! convergence hints in the superblock.
+        //!
+        ResolvedProject(std::set<uint256> candidate_hashes)
+            : m_candidate_hashes(std::move(candidate_hashes))
+        {
+        }
+
+        //!
+        //! \brief Determine whether the supplied manifest part matches a part
+        //! for the convergence of this project.
+        //!
+        //! \param part_hash The hash of a project part from a manifest.
+        //!
+        //! \return \c true if the part hash matches a part annotated for this
+        //! project by a hint in the validated superblock.
+        //!
+        bool Expects(const uint256& part_hash) const
+        {
+            return m_candidate_hashes.count(part_hash);
+        }
+
+        //!
+        //! \brief Get the most recent part resolved from a manifest for this
+        //! project.
+        //!
+        //! \return The hash of the part for this project used to construct a
+        //! convergence for the validated superblock.
+        //!
+        uint256 MostRecentPartHash() const
+        {
+            return m_resolved_parts.rbegin()->second;
+        }
+
+        //!
+        //! \brief Commit the part hash to this project and record the timestamp
+        //! of the manifest.
+        //!
+        //! \param part_hash Hash of the candidate part to commit.
+        //! \param time      Timestamp of the manifest that contains the part.
+        //!
+        void LinkPart(const uint256& part_hash, const int64_t time)
+        {
+            m_resolved_parts.emplace(time, part_hash);
+        }
+    };
+
+    //!
+    //! \brief Reconstructs by-project convergence from local manifest data
+    //! based on project convergence hints from the superblock to produce a
+    //! new superblock used for comparison.
+    //!
+    class ProjectResolver
+    {
+    public:
+        //!
+        //! \brief Initialize a new project resolver.
+        //!
+        //! \param candidate_parts      Map of project names to manifest part
+        //! hashes produced from superblock convergence hints.
+        //! \param manifests_by_scraper Manifest hashes grouped by scraper.
+        //!
+        ProjectResolver(
+            std::map<std::string, std::set<uint256>> candidate_parts,
+            mmCSManifestsBinnedByScraper manifests_by_scraper)
+            : m_manifests_by_scraper(std::move(manifests_by_scraper))
+            , m_supermajority(NumScrapersForSupermajority(m_manifests_by_scraper.size()))
+            , m_latest_manifest_timestamp(0)
+        {
+            for (auto&& project_part_pair : candidate_parts) {
+                m_resolved_projects.emplace(
+                    std::move(project_part_pair.first),
+                    ResolvedProject(std::move(project_part_pair.second)));
+            }
+        }
+
+        //!
+        //! \brief Scan the local manifest data to reconstruct a supermajority
+        //! of manifest parts that match the candidate parts in the superblock.
+        //!
+        //! \return \c false after failing to resolve a matching part for each
+        //! of the projects in the superblock, or when the superblock contains
+        //! only some of the converged projects.
+        //!
+        bool ResolveProjectParts()
+        {
+            // Collect the manifest parts that match the hints in the superblock
+            // and record missing projects, if any:
+            //
+            for (const auto& by_scraper : m_manifests_by_scraper) {
+                const ScraperID& scraper_id = by_scraper.first;
+                const mCSManifest& hashes_by_time = by_scraper.second;
+
+                for (const auto& hashes : hashes_by_time) {
+                    const uint256& manifest_hash = hashes.second.first;
+
+                    ResolvePartsFor(manifest_hash, scraper_id);
+                }
+            }
+
+            // Check that superblock is not missing a project that the scrapers
+            // successfully converged on:
+            //
+            for (const auto& project_pair : m_other_projects) {
+                if (project_pair.second.size() >= m_supermajority) {
+                    LogPrintf(
+                        "ValidateSuperblock(): fallback by-project resolution "
+                        "failed. Converged project %s missing from superblock.",
+                        project_pair.first);
+
+                    return false;
+                }
+            }
+
+            // Check that each of the project parts hinted in the superblock
+            // matched a manifest part that the scrapers converged on:
+            //
+            for (const auto& project_pair : m_resolved_projects) {
+                if (project_pair.second.m_resolved_parts.empty()) {
+                    LogPrintf(
+                        "ValidateSuperblock(): fallback by-project resolution "
+                        "failed. No manifest parts matched project %s.",
+                        project_pair.first);
+
+                    return false;
+                }
+
+                if (project_pair.second.m_scrapers.size() < m_supermajority) {
+                    LogPrintf(
+                        "ValidateSuperblock(): fallback by-project resolution "
+                        "failed. No supermajority exists for project %s.",
+                        project_pair.first);
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        //!
+        //! \brief Construct a superblock from the local manifest data that
+        //! matches the most recent set of resolved project parts.
+        //!
+        //! \return A new superblock instance to compare to the superblock
+        //! under validation.
+        //!
+        Superblock BuildSuperblock() const
+        {
+            ConvergedManifest convergence;
+
+            {
+                LOCK(CScraperManifest::cs_mapManifest);
+
+                const auto iter = CScraperManifest::mapManifest.find(m_latest_manifest_hash);
+
+                // If the manifest for the beacon list disappeared, we cannot
+                // proceed, but the most recent manifest should always exist:
+                if (iter == CScraperManifest::mapManifest.end()) {
+                    LogPrintf("ValidateSuperblock(): beacon list manifest disappeared.");
+                    return Superblock();
+                }
+
+                convergence.ConvergedManifestPartsMap.emplace(
+                    "BeaconList",
+                    iter->second->vParts[0]->data);
+            }
+
+            {
+                LOCK(CSplitBlob::cs_mapParts);
+
+                for (const auto& project_pair : m_resolved_projects) {
+                    const auto iter = CSplitBlob::mapParts.find(
+                        project_pair.second.MostRecentPartHash());
+
+                    // If the resolved part disappeared, we cannot proceed, but
+                    // the most recent project part should always exist:
+                    if (iter == CSplitBlob::mapParts.end()) {
+                        LogPrintf("ValidateSuperblock(): project part disappeared.");
+                        return Superblock();
+                    }
+
+                    convergence.ConvergedManifestPartsMap.emplace(
+                        project_pair.first, // project name
+                        iter->second.data); // serialized part data
+                }
+            }
+
+            return Superblock::FromStats(GetScraperStatsByConvergedManifest(convergence));
+        }
+
+    private:
+        const mmCSManifestsBinnedByScraper m_manifests_by_scraper;
+        const size_t m_supermajority;
+        std::map<std::string, ResolvedProject> m_resolved_projects;
+        std::map<std::string, std::set<ScraperID>> m_other_projects;
+        int64_t m_latest_manifest_timestamp;
+        uint256 m_latest_manifest_hash;
+
+        //!
+        //! \brief Record the supplied scraper ID for the specified project to
+        //! track supermajority status.
+        //!
+        //! \return A reference to the project resolution state if the project
+        //! exists in the superblock.
+        //!
+        boost::optional<ResolvedProject&>
+        TallyProject(const std::string& project, const ScraperID& scraper_id)
+        {
+            if (m_resolved_projects.count(project)) {
+                ResolvedProject& resolved = m_resolved_projects.at(project);
+
+                resolved.m_scrapers.emplace(scraper_id);
+
+                return resolved;
+            }
+
+            m_other_projects[project].emplace(scraper_id);
+
+            return boost::none;
+        }
+
+        //!
+        //! \brief Store the hash and timestamp of the specified manifest if
+        //! the timestamp is more recent than the last seen manifest.
+        //!
+        //! After resolving each project part, the most recent matching manifest
+        //! will provide the manifest part for the convergence beacon list.
+        //!
+        //! \param hash The manifest hash to store.
+        //! \param time Timestamp of the
+        //!
+        void RecordLatestManifest(const uint256& hash, const int64_t time)
+        {
+            if (time > m_latest_manifest_timestamp) {
+                m_latest_manifest_timestamp = time;
+                m_latest_manifest_hash = hash;
+            }
+        }
+
+        //!
+        //! \brief Match each part hinted by the superblock to a local manifest
+        //! published by each scraper.
+        //!
+        //! \param manifest_hash Hash of the manifest to match parts for.
+        //! \param scraper_id    Used to establish supermajority for a manifest.
+        //!
+        void ResolvePartsFor(const uint256& manifest_hash, const ScraperID& scraper_id)
+        {
+            LOCK(CScraperManifest::cs_mapManifest);
+
+            const auto iter = CScraperManifest::mapManifest.find(manifest_hash);
+
+            if (iter == CScraperManifest::mapManifest.end()) {
+                return;
+            }
+
+            const CScraperManifest& manifest = *iter->second;
+
+            for (const auto& entry : manifest.projects) {
+                auto project_option = TallyProject(entry.project, scraper_id);
+
+                // If this project does not exist in the superblock, skip the
+                // attempt to associate its parts:
+                //
+                if (!project_option) {
+                    continue;
+                }
+
+                for (const auto& part : manifest.vParts) {
+                    if (project_option->Expects(part->hash)) {
+                        project_option->LinkPart(part->hash, entry.LastModified);
+                        RecordLatestManifest(manifest_hash, entry.LastModified);
+                    }
+                }
+            }
+        }
+    }; // ProjectResolver
+
+private: // SuperblockValidator fields
+
+    const Superblock& m_superblock; //!< Points to the superblock to validate.
+    const QuorumHash m_quorum_hash; //!< Hash of the superblock to validate.
+
+private: // SuperblockValidator methods
+
+    //!
+    //! \brief Validate the superblock by comparing it to recent past converged
+    //! manifests in the cache.
+    //!
+    //! The scraper convergence cache stores a set of previous convergences for
+    //! the current superblock cycle with matching superblock hashes. This step
+    //! accepts superblocks if the embedded converged manifest hash hints match
+    //! a hash of a past convergence in this cache.
+    //!
+    //! \return \c true if the hinted convergence's superblock hash matches the
+    //! hash of the validated superblock.
+    //!
+    bool TryRecentPastConvergence() const
+    {
+        LOCK(cs_ConvergedScraperStatsCache);
+
+        const uint32_t hint = m_superblock.m_convergence_hint;
+        const auto iter = ConvergedScraperStatsCache.PastConvergences.find(hint);
+
+        return iter != ConvergedScraperStatsCache.PastConvergences.end()
+            && iter->second.first == m_quorum_hash;
+    }
+
+    //!
+    //! \brief Validate the superblock by comparing it to all of the manifests
+    //! stored locally on the node with a content hash that matches the hint.
+    //!
+    //! When no cached manifest matches the superblock, we can try to match it
+    //! to a single manifest with a content hash that the supermajority of the
+    //! scrapers agree on. This routine only selects the manifests that have a
+    //! content hash corresponding to the convergence hint in the superblock.
+    //!
+    //! \return \c true when the hinted manifest's superblock hash matches the
+    //! hash of the validated superblock.
+    //!
+    bool TryByManifest() const
+    {
+        const mmCSManifestsBinnedByScraper manifests_by_scraper = ScraperDeleteCScraperManifests();
+        const size_t supermajority = NumScrapersForSupermajority(manifests_by_scraper.size());
+
+        std::map<uint256, size_t> content_hash_tally;
+
+        for (const auto& by_scraper : manifests_by_scraper) {
+            const mCSManifest& hashes_by_time = by_scraper.second;
+
+            for (const auto& hashes : hashes_by_time) {
+                const uint256& manifest_hash = hashes.second.first;
+                const uint256& content_hash = hashes.second.second;
+
+                if (content_hash.Get64() >> 32 == m_superblock.m_manifest_content_hint) {
+                    if (!content_hash_tally.emplace(content_hash, 1).second) {
+                        content_hash_tally[content_hash]++;
+                    }
+
+                    if (fDebug) {
+                        LogPrintf(
+                            "ValidateSuperblock(): manifest content hash %s "
+                            "matched convergence hint. Matches %" PRIszu,
+                            content_hash.ToString(),
+                            content_hash_tally[content_hash]);
+                    }
+
+                    if (content_hash_tally[content_hash] >= supermajority) {
+                        if (fDebug) {
+                            LogPrintf(
+                                "ValidateSuperblock(): supermajority found for "
+                                "manifest content hash: %s. Trying validation.",
+                                content_hash.ToString());
+                        }
+
+                        if (TryManifest(manifest_hash)) {
+                            return true;
+                        } else {
+                            // Disqualify this content hash:
+                            content_hash_tally[content_hash] = 0;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    //!
+    //! \brief Validate the superblock by comparing the specified manifest.
+    //!
+    //! \return \c true if the specified manifest builds a superblock that
+    //! matches the validated superblock.
+    //!
+    bool TryManifest(const uint256& manifest_hash) const
+    {
+        CScraperManifest manifest;
+
+        {
+            LOCK(CScraperManifest::cs_mapManifest);
+
+            const auto iter = CScraperManifest::mapManifest.find(manifest_hash);
+
+            if (iter == CScraperManifest::mapManifest.end()) {
+                LogPrintf("ValidateSuperblock(): manifest not found");
+                return false;
+            }
+
+            // This is a copy on purpose to minimize lock time.
+            manifest = *iter->second;
+        }
+
+        return TryManifest(manifest);
+    }
+
+    //!
+    //! \brief Validate the superblock by comparing the provided manifest.
+    //!
+    //! \return \c true if the provided manifest builds a superblock that
+    //! matches the validated superblock.
+    //!
+    bool TryManifest(CScraperManifest& manifest) const
+    {
+        const ScraperStats stats = GetScraperStatsFromSingleManifest(manifest);
+
+        return Superblock::FromStats(stats).GetHash() == m_quorum_hash;
+    }
+
+    //!
+    //! \brief Validate the superblock by comparing it to a convergence created
+    //! by matching the project convergence hints in that superblock to project
+    //! parts agreed upon by a supermajority of the scrapers.
+    //!
+    //! In the fallback-to-project-level convergence scenario, superblocks will
+    //! contain project convergence hints for the manifest parts used to create
+    //! the superblock. This routine matches each project convergence hint to a
+    //! manifest part for each project. If a node can reconstruct a convergence
+    //! from those parts agreed upon by a supermajority of scrapers using local
+    //! manifest data, validation passes for the superblock.
+    //!
+    //! Validation will fail if the reconstructed convergence contains projects
+    //! not present in the superblock.
+    //!
+    //! \return \c true if the reconstructed convergence by project builds a
+    //! superblock that matches the validated superblock.
+    //!
+    bool TryProjectFallback() const
+    {
+        const std::map<uint32_t, std::string> hints = CollectPartHints();
+        std::map<std::string, std::set<uint256>> candidates = CollectCandidateParts(hints);
+
+        if (candidates.size() != hints.size()) {
+            LogPrintf(
+                "ValidateSuperblock(): fallback by-project resolution failed. "
+                "Could not match every project convergence hint to a part.");
+
+            return false;
+        }
+
+        ProjectResolver resolver(std::move(candidates), ScraperDeleteCScraperManifests());
+
+        if (!resolver.ResolveProjectParts()) {
+            return false;
+        }
+
+        return resolver.BuildSuperblock().GetHash() == m_quorum_hash;
+    }
+
+    //!
+    //! \brief Build a collection of project-level convergence hints from the
+    //! superblock.
+    //!
+    //! \return A map of manifest project part hints to project names.
+    //!
+    std::map<uint32_t, std::string> CollectPartHints() const
+    {
+        std::map<uint32_t, std::string> hints;
+
+        for (const auto& project_pair : m_superblock.m_projects) {
+            hints.emplace(
+                project_pair.second.m_convergence_hint,
+                project_pair.first); // Project name
+        }
+
+        return hints;
+    }
+
+    //!
+    //! \brief Build a collection of manifest project part hashes from the
+    //! supplied convergence hints.
+    //!
+    //! \return A map of project names to manifest project part hashes.
+    //!
+    std::map<std::string, std::set<uint256>>
+    CollectCandidateParts(const std::map<uint32_t, std::string>& hints) const
+    {
+        struct Candidate
+        {
+            std::string m_project_name;
+            std::set<uint256> m_part_hashes;
+        };
+
+        std::map<uint32_t, Candidate> candidates;
+
+        {
+            LOCK(CSplitBlob::cs_mapParts);
+
+            for (const auto& part_pair : CSplitBlob::mapParts) {
+                uint32_t hint = part_pair.second.hash.Get64() >> 32;
+
+                const auto hint_iter = hints.find(hint);
+
+                if (hint_iter != hints.end()) {
+                    auto iter_pair = candidates.emplace(hint, Candidate());
+                    Candidate& candidate = iter_pair.first->second;
+
+                    // Set the project name if we just inserted a new candidate:
+                    if (iter_pair.second) {
+                        candidate.m_project_name = hint_iter->second;
+                    }
+
+                    candidate.m_part_hashes.emplace(part_pair.second.hash);
+                }
+            }
+        }
+
+        // Pivot the candidate part hashes that match the hints into a map keyed
+        // by project names:
+        //
+        std::map<std::string, std::set<uint256>> candidates_by_project;
+
+        for (auto&& candidate_pair : candidates) {
+            candidates_by_project.emplace(
+                std::move(candidate_pair.second.m_project_name),
+                std::move(candidate_pair.second.m_part_hashes));
+        }
+
+        return candidates_by_project;
+    }
+}; // SuperblockValidator
+
 //!
 //! \brief Parses and unpacks superblock data from legacy superblock contracts.
 //!
@@ -229,6 +901,43 @@ static_assert(offsetof(struct BinaryResearcher, magnitude) ==
 
 // -----------------------------------------------------------------------------
 // Functions
+// -----------------------------------------------------------------------------
+
+bool NN::ValidateSuperblock(const Superblock& superblock, const bool use_cache)
+{
+    using Result = SuperblockValidator::Result;
+
+    const Result result = SuperblockValidator(superblock).Validate(use_cache);
+    std::string message;
+
+    switch (result) {
+        case Result::UNKNOWN:
+            message = "UNKNOWN - Waiting for manifest data";
+            break;
+        case Result::INVALID:
+            message = "INVALID - Validation failed";
+            break;
+        case Result::VALID_CURRENT:
+            message = "VALID_CURRENT - Matched current cached convergence";
+            break;
+        case Result::VALID_PAST:
+            message = "VALID_PAST - Matched past cached convergence";
+            break;
+        case Result::VALID_BY_MANIFEST:
+            message = "VALID_BY_MANIFEST - Matched supermajority by manifest";
+            break;
+        case Result::VALID_BY_PROJECT:
+            message = "VALID_BY_PROJECT - Matched supermajority by project";
+            break;
+    }
+
+    LogPrintf("ValidateSuperblock(): %s.", message);
+
+    return result != Result::INVALID;
+}
+
+// -----------------------------------------------------------------------------
+// Legacy Functions
 // -----------------------------------------------------------------------------
 
 std::string UnpackBinarySuperblock(std::string sBlock)

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1023,6 +1023,7 @@ std::string PackBinarySuperblock(std::string sBlock)
 Superblock::Superblock()
     : m_version(Superblock::CURRENT_VERSION)
     , m_convergence_hint(0)
+    , m_manifest_content_hint(0)
     , m_height(0)
     , m_timestamp(0)
 {

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -1,9 +1,7 @@
-#include "net.h" // TODO: needed for scraper_net.h
-#include <univalue.h> // TODO: needed for scraper_net.h
-
 #include "compat/endian.h"
 #include "neuralnet/superblock.h"
 #include "scraper_net.h"
+#include "sync.h"
 #include "util.h"
 
 #include <boost/variant/apply_visitor.hpp>

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -350,11 +350,46 @@ private: // SuperblockValidator classes
         }
 
     private:
+        //!
+        //! \brief Manifest hashes grouped by scraper to resolve a by-project
+        //! fallback convergence from.
+        //!
         const mmCSManifestsBinnedByScraper m_manifests_by_scraper;
+
+        //!
+        //! \brief The number of scrapers that must agree about a project to
+        //! consider it valid in a superblock.
+        //!
         const size_t m_supermajority;
+
+        //!
+        //! \brief Contains the project resolution context for each of the
+        //! projects hinted in the superblock.
+        //!
+        //! Keyed by project name.
+        //!
         std::map<std::string, ResolvedProject> m_resolved_projects;
+
+        //!
+        //! \brief Contains the scrapers that published manifest data for any
+        //! projects not hinted in the superblock.
+        //!
+        //! Keyed by project name. A scraper supermajority for any project
+        //! disqualifies the superblock (it failed to include the project).
+        //!
         std::map<std::string, std::set<ScraperID>> m_other_projects;
+
+        //!
+        //! \brief Timestamp of the most recent manifest matched to a project
+        //! in the superblock.
+        //!
         int64_t m_latest_manifest_timestamp;
+
+        //!
+        //! \brief Hash of the most recent manifest matched to a project in the
+        //! superblock. The beacon list part of the resolved convergence result
+        //! comes from this manifest.
+        //!
         uint256 m_latest_manifest_hash;
 
         //!

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -858,6 +858,18 @@ private:
     //!
     mutable QuorumHash m_hash_cache;
 }; // Superblock
+
+
+//!
+//! \brief Validate the supplied superblock by comparing it to local manifest
+//! data.
+//!
+//! \param superblock The superblock to validate.
+//! \param use_cache  If \c false, skip validation with the scraper cache.
+//!
+//! \return \c True if the local manifest data produces a matching superblock.
+//!
+bool ValidateSuperblock(const Superblock& superblock, const bool use_cache = true);
 } // namespace NN
 
 namespace std {

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -739,6 +739,7 @@ public:
         if (!(nType & SER_GETHASH)) {
             READWRITE(m_version);
             READWRITE(m_convergence_hint);
+            READWRITE(m_manifest_content_hint);
         }
 
         nVersion = m_version;

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -944,7 +944,6 @@ struct ConvergedScraperStats
 
     // New superblock object and hash.
     NN::Superblock NewFormatSuperblock;
-    NN::QuorumHash nNewFormatSuperblockHash;
 
     uint32_t GetVersion()
     {
@@ -963,7 +962,7 @@ struct ConvergedScraperStats
         {
             // This is specifically this form of insert to insure that if there is a hint "collision" the referenced
             // SB Hash and Convergence stored will be the LATER one.
-            PastConvergences[nReducedContentHash] = std::make_pair(nNewFormatSuperblockHash, Convergence);
+            PastConvergences[nReducedContentHash] = std::make_pair(NewFormatSuperblock.GetHash(), Convergence);
         }
     }
 

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -4799,9 +4799,9 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bCon
                     ConvergedScraperStatsCache.bClean = true;
 
                     // Signal UI of SBContract status
-                    if (superblock.GetSerializeSize(SER_NETWORK, 1))
+                    if (superblock.WellFormed())
                     {
-                        if (superblock_Prev.GetSerializeSize(SER_NETWORK, 1))
+                        if (superblock_Prev.WellFormed())
                         {
                             // If the current is not empty and the previous is not empty and not the same, then there is an updated contract.
                             if (superblock.GetHash() != superblock_Prev.GetHash())
@@ -4812,7 +4812,7 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bCon
                             uiInterface.NotifyScraperEvent(scrapereventtypes::SBContract, CT_NEW, {});
                     }
                     else
-                        if (superblock_Prev.GetSerializeSize(SER_NETWORK, 1))
+                        if (superblock_Prev.WellFormed())
                             // If the current is empty and the previous was not empty, then the contract has been deleted.
                             uiInterface.NotifyScraperEvent(scrapereventtypes::SBContract, CT_DELETED, {});
 
@@ -4843,7 +4843,7 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats, bool bCon
             superblock = NN::Superblock::FromStats(mScraperStats);
 
             // Signal the UI there is a contract.
-            if(superblock.GetSerializeSize(SER_NETWORK, 1))
+            if(superblock.WellFormed())
                 uiInterface.NotifyScraperEvent(scrapereventtypes::SBContract, CT_NEW, {});
 
             _log(logattribute::INFO, "ScraperGetNeuralContract", "Superblock object generated from single shot");

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -5645,7 +5645,11 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
     _log(logattribute::INFO, "testnewsb", "NewFormatSuperblock legacy unpack number of zero mags = " + std::to_string(NewFormatSuperblock.m_cpids.Zeros()));
     res.pushKV("NewFormatSuperblock legacy unpack number of zero mags", std::to_string(NewFormatSuperblock.m_cpids.Zeros()));
 
-    scraperSBvalidationtype validity = ValidateSuperblock(NewFormatSuperblock, true);
+    //
+    // ValidateSuperblock() reference function tests (current convergence)
+    //
+
+    scraperSBvalidationtype validity = ::ValidateSuperblock(NewFormatSuperblock, true);
 
     if (validity != scraperSBvalidationtype::Invalid && validity != scraperSBvalidationtype::Unknown)
     {
@@ -5658,7 +5662,7 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
         res.pushKV("NewFormatSuperblock validation against current (using cache)", "failed - " + GetTextForscraperSBvalidationtype(validity));
     }
 
-    scraperSBvalidationtype validity2 = ValidateSuperblock(NewFormatSuperblock, false);
+    scraperSBvalidationtype validity2 = ::ValidateSuperblock(NewFormatSuperblock, false);
 
     if (validity2 != scraperSBvalidationtype::Invalid && validity2 != scraperSBvalidationtype::Unknown)
     {
@@ -5669,6 +5673,32 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
     {
         _log(logattribute::INFO, "testnewsb", "NewFormatSuperblock validation against current (without using cache) failed - " + GetTextForscraperSBvalidationtype(validity2));
         res.pushKV("NewFormatSuperblock validation against current (without using cache)", "failed - " + GetTextForscraperSBvalidationtype(validity2));
+    }
+
+    //
+    // SuperblockValidator class tests (current convergence)
+    //
+
+    if (NN::ValidateSuperblock(NewFormatSuperblock))
+    {
+        _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against current (using cache) passed");
+        res.pushKV("NN::ValidateSuperblock validation against current (using cache)", "passed");
+    }
+    else
+    {
+        _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against current (using cache) failed");
+        res.pushKV("NN::ValidateSuperblock validation against current (using cache)", "failed");
+    }
+
+    if (NN::ValidateSuperblock(NewFormatSuperblock, false))
+    {
+        _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against current (without using cache) passed");
+        res.pushKV("NN::ValidateSuperblock validation against current (without using cache)", "passed");
+    }
+    else
+    {
+        _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against current (without using cache) failed");
+        res.pushKV("NN::ValidateSuperblock validation against current (without using cache)", "failed");
     }
 
     ConvergedManifest RandomPastConvergedManifest;
@@ -5721,7 +5751,11 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
             }
         }
 
-        scraperSBvalidationtype validity3 = ValidateSuperblock(RandomPastSB, true);
+        //
+        // ValidateSuperblock() reference function tests (past convergence)
+        //
+
+        scraperSBvalidationtype validity3 = ::ValidateSuperblock(RandomPastSB, true);
 
         if (validity3 != scraperSBvalidationtype::Invalid && validity != scraperSBvalidationtype::Unknown)
         {
@@ -5734,7 +5768,7 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
             res.pushKV("NewFormatSuperblock validation against random past (using cache)", "failed - " + GetTextForscraperSBvalidationtype(validity3));
         }
 
-        scraperSBvalidationtype validity4 = ValidateSuperblock(RandomPastSB, false);
+        scraperSBvalidationtype validity4 = ::ValidateSuperblock(RandomPastSB, false);
 
         if (validity4 != scraperSBvalidationtype::Invalid && validity != scraperSBvalidationtype::Unknown)
         {
@@ -5745,6 +5779,32 @@ UniValue testnewsb(const UniValue& params, bool fHelp)
         {
             _log(logattribute::INFO, "testnewsb", "NewFormatSuperblock validation against random past (without using cache) failed - " + GetTextForscraperSBvalidationtype(validity4));
             res.pushKV("NewFormatSuperblock validation against random past (without using cache)", "failed - " + GetTextForscraperSBvalidationtype(validity4));
+        }
+
+        //
+        // SuperblockValidator class tests (past convergence)
+        //
+
+        if (NN::ValidateSuperblock(RandomPastSB))
+        {
+            _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against random past (using cache) passed");
+            res.pushKV("NN::ValidateSuperblock validation against random past (using cache)", "passed");
+        }
+        else
+        {
+            _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against random past (using cache) failed");
+            res.pushKV("NN::ValidateSuperblock validation against random past (using cache)", "failed");
+        }
+
+        if (NN::ValidateSuperblock(RandomPastSB, false))
+        {
+            _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against random past (without using cache) passed");
+            res.pushKV("NN::ValidateSuperblock validation against random past (without using cache)", "passed");
+        }
+        else
+        {
+            _log(logattribute::INFO, "testnewsb", "NN::ValidateSuperblock validation against random past (without using cache) failed");
+            res.pushKV("NN::ValidateSuperblock validation against random past (without using cache)", "failed");
         }
     }
 

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -122,7 +122,6 @@ bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& 
 std::string ScraperGetNeuralContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
 NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
 std::string ScraperGetNeuralHash();
-NN::QuorumHash ScraperGetSuperblockHash();
 bool ScraperSynchronizeDPOR();
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache = true);
 

--- a/src/scraper_net.h
+++ b/src/scraper_net.h
@@ -1,12 +1,18 @@
+#pragma once
+
 /* scraper_net.h */
 
 /* Maybe the parts system will be useful for other things so let's abstract
- * that to parent class. Sice it will be all in one file there will not be any
+ * that to parent class. Since it will be all in one file there will not be any
  * polymorphism.
 */
 
-#include <key.h>
+#include "net.h"
 #include "sync.h"
+
+#include <key.h>
+#include <univalue.h>
+
 
 /** Abstract class for blobs that are split into parts. */
 class CSplitBlob

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -261,6 +261,8 @@ ConvergedScraperStats GetTestConvergence(const bool by_parts = false)
     convergence.Convergence.bByParts = by_parts;
     convergence.Convergence.nContentHash
         = uint256("1111111111111111111111111111111111111111111111111111111111111111");
+    convergence.Convergence.nUnderlyingManifestContentHash
+        = uint256("2222222222222222222222222222222222222222222222222222222222222222");
 
     // Add some project parts with the same names as the projects in the stats.
     // The part data doesn't matter, so we just add empty containers.
@@ -374,6 +376,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_an_empty_superblock)
 
     BOOST_CHECK(superblock.m_version == NN::Superblock::CURRENT_VERSION);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     BOOST_CHECK(superblock.m_cpids.empty() == true);
     BOOST_CHECK(superblock.m_cpids.TotalMagnitude() == 0);
@@ -393,6 +396,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_to_the_specified_version)
 
     BOOST_CHECK(superblock.m_version == 1);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     BOOST_CHECK(superblock.m_cpids.empty() == true);
     BOOST_CHECK(superblock.m_cpids.TotalMagnitude() == 0);
@@ -412,6 +416,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_set_of_scraper_statistics)
 
     BOOST_CHECK(superblock.m_version == NN::Superblock::CURRENT_VERSION);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == 2);
@@ -455,6 +460,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_provided_scraper_convergnce)
     // This initialization mode must set the convergence hint derived from
     // the content hash of the convergence:
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
 
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == 2);
@@ -497,6 +503,8 @@ BOOST_AUTO_TEST_CASE(it_initializes_from_a_fallback_by_project_scraper_convergnc
 
     BOOST_CHECK(superblock.m_version == NN::Superblock::CURRENT_VERSION);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
+    // Manifest content hint not set for fallback convergence:
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x00000000);
 
     auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == 2);
@@ -571,6 +579,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_binary_contract)
     // Legacy string-packed superblocks unpack to version 1:
     BOOST_CHECK(superblock.m_version == 1);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     BOOST_CHECK(superblock.m_cpids.size() == 3);
     BOOST_CHECK(superblock.m_cpids.Zeros() == 5);
@@ -634,6 +643,7 @@ BOOST_AUTO_TEST_CASE(it_initializes_by_unpacking_a_legacy_text_contract)
     // Legacy string-packed superblocks unpack to version 1:
     BOOST_CHECK(superblock.m_version == 1);
     BOOST_CHECK(superblock.m_convergence_hint == 0);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0);
 
     BOOST_CHECK(superblock.m_cpids.size() == 3);
     BOOST_CHECK(superblock.m_cpids.Zeros() == 0);
@@ -806,6 +816,7 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
     std::vector<unsigned char> expected {
         0x02, 0x00, 0x00, 0x00,                         // Version
         0x11, 0x11, 0x11, 0x11,                         // Convergence hint
+        0x22, 0x22, 0x22, 0x22,                         // Manifest content hint
         0x02,                                           // CPIDs size
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
@@ -844,6 +855,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
     std::vector<unsigned char> bytes {
         0x02, 0x00, 0x00, 0x00,                         // Version
         0x11, 0x11, 0x11, 0x11,                         // Convergence hint
+        0x22, 0x22, 0x22, 0x22,                         // Manifest content hint
         0x02,                                           // CPIDs size
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
@@ -873,6 +885,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
 
     BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
 
     const auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == 2);
@@ -917,6 +930,7 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
     std::vector<unsigned char> expected {
         0x02, 0x00, 0x00, 0x00,                         // Version
         0x11, 0x11, 0x11, 0x11,                         // Convergence hint
+        0x00, 0x00, 0x00, 0x00,                         // Manifest content hint
         0x02,                                           // CPIDs size
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
@@ -961,6 +975,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
     std::vector<unsigned char> bytes {
         0x02, 0x00, 0x00, 0x00,                         // Version
         0x11, 0x11, 0x11, 0x11,                         // Convergence hint
+        0x22, 0x22, 0x22, 0x22,                         // Manifest content hint
         0x02,                                           // CPIDs size
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // CPID 1
         0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, // ...
@@ -992,6 +1007,7 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
 
     BOOST_CHECK(superblock.m_version == 2);
     BOOST_CHECK(superblock.m_convergence_hint == 0x11111111);
+    BOOST_CHECK(superblock.m_manifest_content_hint == 0x22222222);
 
     const auto& cpids = superblock.m_cpids;
     BOOST_CHECK(cpids.size() == 2);


### PR DESCRIPTION
These changes refactor the original `ValidateSuperblock()` function into a `SuperblockValidator` class. The original implementation is retained for reference and testing.